### PR TITLE
Results from Chrome 107 / Mac OS 10.15.7 / Collector v6.2.7-68-gca5dfaef

### DIFF
--- a/6.2.7-68-gca5dfaef-chrome-107.0.0.0-mac-os-10.15.7-d1ac2bf47c.json
+++ b/6.2.7-68-gca5dfaef-chrome-107.0.0.0-mac-os-10.15.7-d1ac2bf47c.json
@@ -1,0 +1,1 @@
+{"__version":"6.2.7-68-gca5dfaef","results":{},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36
Browser: Chrome 107 (on Mac OS 10.15.7)
Hash Digest: d1ac2bf47c
Test URLs: 

**WARNING:** this PR was created from a development/staging version!